### PR TITLE
translate single key: Fix empty text if no translation exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ By default, if `data-i18n-attr` is not defined, the `innerHTML` will be translat
 
 ### Translating programmatically
 
-Alternatively, you can translate a single, given key via the method `getTranslationByKey(lang, key, fallback)`. The first argument should be a valid language string like "en" or "de", the second argument should be a key from your translation files, such as "header.title", the third argument handles possible fallback to `defaultLanguage` (true/false).
+Alternatively, you can translate a single, given key via the method `getTranslationByKey(lang, key)`. The first argument should be a valid language string like "en" or "de", the second argument should be a key from your translation files, such as "header.title".
 
 ```js
 translator
-  .getTranslationByKey("en", "header.title", true)
+  .getTranslationByKey("en", "header.title")
   .then((translation) => console.log(translation));
 // --> prints "English title"
 ```

--- a/src/translator.js
+++ b/src/translator.js
@@ -94,6 +94,9 @@ class Translator {
       );
 
       text = this._getValueFromJSON(key, fallbackTranslation, false);
+    } else if (!text) {
+      text = key;
+      console.warn(`Could not find text for attribute "${key}".`);
     }
 
     return text;
@@ -108,9 +111,7 @@ class Translator {
       if (text) {
         element[property] = text;
       } else {
-        element[property] = element.dataset.i18n;
-
-        console.warn(`Could not find text for attribute "${key}".`);
+        console.error(`Could not find text for attribute "${key}".`);
       }
     };
 


### PR DESCRIPTION
At the moment `key` is not used as `text` if we only translate a single, given key - let's fix that.

Also fix the README because we handle the fallback at `_getValueFromJSON` and not at `getTranslationByKey`. Revert previously merged README change.

**before:**
![Screenshot_20200408-210628__01](https://user-images.githubusercontent.com/6080900/78823648-53ddce80-79dd-11ea-88f9-0f6d4bf2c2fc.jpg)

**after:**
![Screenshot_20200408-210645__01__01](https://user-images.githubusercontent.com/6080900/78823675-60622700-79dd-11ea-9f3e-e7625b12f672.jpg)

