### PR TITLE
allow multiple i18n attribute values

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -104,22 +104,28 @@ class Translator {
 
   _translate(translation) {
     var zip = (keys, values) => keys.map((key, i) => [key, values[i]]);
+    var nullSafeSplit = (str, separator) => str ? str.split(separator) : null;
+
     var replace = (element) => {
-      var keys = element.getAttribute("data-i18n")?.split(' ');
-      var properties = element.getAttribute("data-i18n-attr")?.split(' ') || ["innerHTML"];
-      var pairs = zip(keys, properties);
-
-      pairs.forEach(pair => {
-        const [key, property] = pair;
-        var text = this._getValueFromJSON(key, translation, true);
-
-        if (text) {
-          element[property] = text;
-          element.setAttribute(property, text);
-        } else {
-          console.error(`Could not find text for attribute "${key}".`);
-        }
-      });
+      var keys = nullSafeSplit(element.getAttribute("data-i18n"), ' ') || [];
+      var properties = nullSafeSplit(element.getAttribute("data-i18n-attr"), ' ') || ["innerHTML"];
+      
+      if(keys.length > 0 && keys.length !== properties.length) {
+        console.error("data-i18n and data-i18n-attr must contain the same number of items");
+      } else {
+        var pairs = zip(keys, properties);
+        pairs.forEach(pair => {
+          const [key, property] = pair;
+          var text = this._getValueFromJSON(key, translation, true);
+  
+          if (text) {
+            element[property] = text;
+            element.setAttribute(property, text);
+          } else {
+            console.error(`Could not find text for attribute "${key}".`);
+          }
+        });
+      }
     };
 
     this._elements.forEach(replace);

--- a/src/translator.js
+++ b/src/translator.js
@@ -103,16 +103,23 @@ class Translator {
   }
 
   _translate(translation) {
+    var zip = (keys, values) => keys.map((key, i) => [key, values[i]]);
     var replace = (element) => {
-      var key = element.getAttribute("data-i18n");
-      var property = element.getAttribute("data-i18n-attr") || "innerHTML";
-      var text = this._getValueFromJSON(key, translation, true);
+      var keys = element.getAttribute("data-i18n")?.split(' ');
+      var properties = element.getAttribute("data-i18n-attr")?.split(' ') || ["innerHTML"];
+      var pairs = zip(keys, properties);
 
-      if (text) {
-        element[property] = text;
-      } else {
-        console.error(`Could not find text for attribute "${key}".`);
-      }
+      pairs.forEach(pair => {
+        const [key, property] = pair;
+        var text = this._getValueFromJSON(key, translation, true);
+
+        if (text) {
+          element[property] = text;
+          element.setAttribute(property, text);
+        } else {
+          console.error(`Could not find text for attribute "${key}".`);
+        }
+      });
     };
 
     this._elements.forEach(replace);


### PR DESCRIPTION
My dad ran into a limitation where you can't translate multiple attributes within the same HTML element (e.g. in an `input` with `placeholder` and `data-msg`) so I made this fix to allow ordered space-separated values in `data-i18n` and `data-i18n-attr`, following the convention for other attributes that take multiple values (like `class`).