### PR TITLE
feat(translator): convert NodeList into an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2020-08-04
+
+### Changed
+
+- Added compatibility for older browsers (including Safari 9) by using `Array.from` to convert a NodeList into an array.
+
 ## [2.0.1] - 2020-07-30
 
 ### Changed
@@ -28,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `remove()` to remove languages from the translator.
 - Added `translateForKey()` and `translatePageTo()` to translate single keys or the entire website.
 - Added `get currentLanguage` to get the currently used language.
-- Transpiled and minified UMD, ESM and CJS builds are available via [unpkg](https://unpkg.com/@andreasremdt/simple-translator@2.0.0/dist/umd/translator.min.js) and [npm](https://www.npmjs.com/package/@andreasremdt/simple-translator).
+- Transpiled and minified UMD, ESM and CJS builds are available via [unpkg](https://unpkg.com/@andreasremdt/simple-translator@latest/dist/umd/translator.min.js) and [npm](https://www.npmjs.com/package/@andreasremdt/simple-translator).
 - Added a build system for easier packaging and testing.
 - Added [CONTRIBUTING.md](https://github.com/andreasremdt/simple-translator/CONTRIBUTING.md)
 - Added [CODE_OF_CONDUCT.md](https://github.com/andreasremdt/simple-translator/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A UMD build is available via [unpkg](https://unpkg.com). Just paste the followin
 
 ```html
 <script
-  src="https://unpkg.com/@andreasremdt/simple-translator@2.0.0/dist/umd/translator.min.js"
+  src="https://unpkg.com/@andreasremdt/simple-translator@latest/dist/umd/translator.min.js"
   defer
 ></script>
 ```
@@ -96,7 +96,7 @@ Want to see the bigger picture? Check out the live demos at CodeSandbox and see 
 
 <!-- Load the translator either from a CDN or locally -->
 <script
-  src="https://unpkg.com/@andreasremdt/simple-translator@2.0.0/dist/umd/translator.min.js"
+  src="https://unpkg.com/@andreasremdt/simple-translator@latest/dist/umd/translator.min.js"
   defer
 ></script>
 <script defer>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@andreasremdt/simple-translator",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Simple client-side translation with pure JavaScript.",
   "main": "dist/cjs/translator.min.js",
   "module": "dist/esm/translator.min.js",

--- a/src/translator.js
+++ b/src/translator.js
@@ -167,7 +167,7 @@ class Translator {
 
     const elements =
       typeof this.config.selector == 'string'
-        ? document.querySelectorAll(this.config.selector)
+        ? Array.from(document.querySelectorAll(this.config.selector))
         : this.config.selector;
 
     if (elements.length && elements.length > 0) {


### PR DESCRIPTION
Older browsers like Safari 9 don't support the `.forEach` method on `NodeList`arrays, but they do support the conversion with `Array.from`.

In this PR, support for older browsers is increased by converting the `NodeList` into an array before using it.

Besides that, the documentation has been updated to always include the latest link to [unpkg](https://unpkg.com).